### PR TITLE
Add colorful mobile-friendly splash and chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "explain-like-im-5-app",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "lucide-react": "^0.263.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ask Like I'm 5</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Poppins', 'sans-serif'],
+            },
+          },
+        },
+      };
+    </script>
+  </head>
+  <body class="font-sans bg-gradient-to-br from-purple-200 via-pink-200 to-yellow-100 min-h-screen">
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { Send } from 'lucide-react';
+
+const Splash = ({ onStart }) => (
+  <div className="min-h-screen flex flex-col items-center justify-center text-center space-y-8 p-6">
+    <h1 className="text-5xl font-bold text-purple-700 drop-shadow-sm">Ask Like I'm 5</h1>
+    <p className="text-gray-700 max-w-xs">A friendly chatbot for everyone, designed to be super easy for anyone to use.</p>
+    <button
+      onClick={onStart}
+      className="px-8 py-3 bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-full shadow-lg hover:from-pink-600 hover:to-purple-700"
+    >
+      Start Chatting
+    </button>
+  </div>
+);
+
+const Chat = () => {
+  const [input, setInput] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  const handleSend = () => {
+    if (!input.trim()) return;
+    setMessages([...messages, { from: 'user', text: input }]);
+    // Placeholder response
+    setTimeout(() => {
+      setMessages(current => [
+        ...current,
+        { from: 'bot', text: "I'm still learning, but imagine a helpful response here!" }
+      ]);
+    }, 500);
+    setInput('');
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="text-lg font-semibold text-purple-700 py-4 text-center shadow-md bg-white/60 backdrop-blur-md">
+        Ask Like I'm 5
+      </header>
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {messages.map((m, idx) => (
+          <div
+            key={idx}
+            className={`px-4 py-2 rounded-2xl max-w-xs text-sm ${
+              m.from === 'user'
+                ? 'bg-gradient-to-br from-pink-500 to-purple-600 text-white self-end'
+                : 'bg-white/70 backdrop-blur-md text-gray-800 self-start'
+            }`}
+          >
+            {m.text}
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center gap-2 p-3 bg-white/60 backdrop-blur-md">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="flex-1 p-3 rounded-full border border-gray-300 focus:outline-none"
+          placeholder="Type your question..."
+        />
+        <button
+          onClick={handleSend}
+          className="p-3 bg-gradient-to-r from-pink-500 to-purple-600 rounded-full text-white disabled:opacity-50"
+          disabled={!input.trim()}
+        >
+          <Send size={20} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const App = () => {
+  const [started, setStarted] = useState(false);
+  return started ? <Chat /> : <Splash onStart={() => setStarted(true)} />;
+};
+
+export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- initialize React project structure
- add colorful splash screen with text "Ask Like I'm 5"
- implement simple chat interface with placeholder bot replies
- target mobile (iPhone) friendly layout
- refine UI to use gradient styling and fonts

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684cc525cc6083298e643c3e49f216a0