### PR TITLE
Switch app to iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Explain Like I'm 5 App
 
-A minimal macOS application written in SwiftUI that gives easy to understand answers to common questions.
+A minimal iPhone application written in SwiftUI that gives easy to understand answers to common questions.
 
-## INSTALL (macOS)
+## INSTALL (iOS)
 
 1. Install [Xcode](https://developer.apple.com/xcode/) from the Mac App Store. Xcode includes the Swift and SwiftUI tools used to build the app.
 2. Clone this repository:
@@ -13,6 +13,6 @@ A minimal macOS application written in SwiftUI that gives easy to understand ans
 3. Build and run the application:
    ```bash
    cd swift
-   swift run
+   open Package.swift
    ```
-   You can also open `Package.swift` in Xcode and press **Run** to launch the app.
+   Choose an iOS simulator target in Xcode and press **Run** to launch the app.

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ExplainLikeIm5App",
     platforms: [
-        .macOS(.v12)
+        .iOS(.v15)
     ],
     products: [
         .executable(name: "ExplainLikeIm5App", targets: ["ExplainLikeIm5App"])


### PR DESCRIPTION
## Summary
- update README instructions to target iOS simulator
- set Package.swift platform to `.iOS(.v15)`

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_684d050d0c0483298c65cb9145743acc